### PR TITLE
Enhance "fixed exposure" and "quick exposure" 

### DIFF
--- a/exposure.c
+++ b/exposure.c
@@ -89,13 +89,13 @@ ec_t ec_normalize(ec_t ec) {
 }
 
 ec_t ec_inc(ec_t ec, int extended) {
-	ec = ec_normalize(ec_normalize(ec) + EV_CODE(0, DPData.cf_explevel_inc_third ? 4 : 3));
+	ec = ec_normalize(ec_normalize(ec) + EV_STEP);
 
 	return MIN(ec, extended ? EC_MAX_EXT : EC_MAX);
 }
 
 ec_t ec_dec(ec_t ec, int extended) {
-	ec = ec_normalize(ec_normalize(ec) - EV_CODE(0, DPData.cf_explevel_inc_third ? 4 : 3));
+	ec = ec_normalize(ec_normalize(ec) - EV_STEP);
 
 	return MAX(ec, extended ? EC_MIN_EXT : EC_MIN);
 }
@@ -167,11 +167,11 @@ av_t av_sub(av_t ying, av_t yang) {
 }
 
 av_t av_inc(av_t av) {
-	return av_add(av, EV_CODE(0, DPData.cf_explevel_inc_third ? 4 : 3));
+	return av_add(av, EV_STEP);
 }
 
 av_t av_dec(av_t av) {
-	return av_sub(av, EV_CODE(0, DPData.cf_explevel_inc_third ? 4 : 3));
+	return av_sub(av, EV_STEP);
 }
 
 void av_print(char *dest, av_t av) {
@@ -217,11 +217,11 @@ tv_t tv_sub(tv_t ying, tv_t yang) {
 }
 
 tv_t tv_inc(tv_t tv) {
-	return tv_add(tv, EV_CODE(0, DPData.cf_explevel_inc_third ? 4 : 3));
+	return tv_add(tv, EV_STEP);
 }
 
 tv_t tv_dec(tv_t tv) {
-	return tv_sub(tv, EV_CODE(0, DPData.cf_explevel_inc_third ? 4 : 3));
+	return tv_sub(tv, EV_STEP);
 }
 
 tv_t bulb_next(tv_t tv) {

--- a/exposure.c
+++ b/exposure.c
@@ -273,16 +273,6 @@ void bulb_print(char *dest, tv_t tv) {
 
 /* ISO related --------------------------------------------------------- */
 
-iso_t iso_roll(iso_t iso) {
-	int step = (1 << settings.digital_iso_step);
-	int mask = 0x100 - step;
-
-	iso = iso & mask;
-	iso = EV_CODE(EV_VAL(iso), (EV_SUB(iso) + step) % 8);
-
-	return MIN(iso, ISO_EXT);
-}
-
 iso_t iso_next(iso_t iso) {
 	iso = EV_CODE(EV_VAL(iso) + 1, 0);
 

--- a/exposure.c
+++ b/exposure.c
@@ -88,16 +88,16 @@ ec_t ec_normalize(ec_t ec) {
 	return ec + SIGN(ec) * ev_normalization[DPData.cf_explevel_inc_third][abs(EV_SUB(ec))];
 }
 
-ec_t ec_inc(ec_t ec) {
+ec_t ec_inc(ec_t ec, int extended) {
 	ec = ec_normalize(ec_normalize(ec) + EV_CODE(0, DPData.cf_explevel_inc_third ? 4 : 3));
 
-	return MIN(ec, EC_MAX);
+	return MIN(ec, extended ? EC_MAX_EXT : EC_MAX);
 }
 
-ec_t ec_dec(ec_t ec) {
+ec_t ec_dec(ec_t ec, int extended) {
 	ec = ec_normalize(ec_normalize(ec) - EV_CODE(0, DPData.cf_explevel_inc_third ? 4 : 3));
 
-	return MAX(ec, EC_MIN);
+	return MAX(ec, extended ? EC_MIN_EXT : EC_MIN);
 }
 
 ec_t ec_add(ec_t ying, ec_t yang) {

--- a/exposure.h
+++ b/exposure.h
@@ -77,7 +77,6 @@ extern tv_t bulb_prev(tv_t tv);
 extern void tv_print  (char *dest, tv_t tv);
 extern void bulb_print(char *dest, tv_t tv);
 
-extern iso_t iso_roll(iso_t iso);
 extern iso_t iso_next(iso_t iso);
 extern iso_t iso_prev(iso_t iso);
 extern iso_t iso_inc (iso_t iso);

--- a/exposure.h
+++ b/exposure.h
@@ -16,6 +16,7 @@ typedef unsigned char iso_t;
 #define EV_ROUND(code) EV_TRUNC(code + EV_CODE(0, 4))
 
 #define EV_ZERO EV_CODE( 0, 0)  //  0EV
+#define EV_STEP EV_CODE(0, DPData.cf_explevel_inc_third ? 4 : 3) // 1/3 or 1/5
 
 #define EC_ZERO    EV_CODE(  0, 0)  //   0EV
 #define EC_MIN     EV_CODE( -6, 0)  //  +6EV

--- a/exposure.h
+++ b/exposure.h
@@ -17,9 +17,11 @@ typedef unsigned char iso_t;
 
 #define EV_ZERO EV_CODE( 0, 0)  //  0EV
 
-#define EC_ZERO EV_CODE( 0, 0)  //  0EV
-#define EC_MIN  EV_CODE(-6, 0)  // +6EV
-#define EC_MAX  EV_CODE(+6, 0)  // -6EV
+#define EC_ZERO    EV_CODE(  0, 0)  //   0EV
+#define EC_MIN     EV_CODE( -6, 0)  //  +6EV
+#define EC_MAX     EV_CODE( +6, 0)  //  -6EV
+#define EC_MIN_EXT EV_CODE(-15, 0)  // -15EV
+#define EC_MAX_EXT EV_CODE(+15, 0)  // +15EV
 
 #define AV_MIN EV_CODE( 1, 0)  // f/1.0
 #define AV_MAX EV_CODE(13, 0)  // f/64
@@ -50,8 +52,8 @@ extern ev_t ev_time     (int s);
 extern ev_t ev_normalize(ev_t ec);
 extern ec_t ec_normalize(ec_t ec);
 
-extern ec_t ec_inc(ec_t ev);
-extern ec_t ec_dec(ec_t ev);
+extern ec_t ec_inc(ec_t ev, int extended);
+extern ec_t ec_dec(ec_t ev, int extended);
 extern ec_t ec_add(ec_t ying, ec_t yang);
 extern ec_t ec_sub(ec_t ying, ec_t yang);
 

--- a/menuitem.c
+++ b/menuitem.c
@@ -112,7 +112,7 @@ void menuitem_print(char *buffer, const char *name, const char *parameter, const
 }
 
 void menuitem_inc_ec(const menuitem_t *item, const int repeating) {
-	*item->parm.menuitem_ec.value = ec_inc(*item->parm.menuitem_ec.value);
+	*item->parm.menuitem_ec.value = ec_inc(*item->parm.menuitem_ec.value, item->parm.menuitem_ec.extended);
 }
 
 void menuitem_inc_av(const menuitem_t *item, const int repeating) {
@@ -187,7 +187,7 @@ void menuitem_dec_ec(const menuitem_t *item, const int repeating) {
 	if (item->parm.menuitem_ec.zero_means_off && *item->parm.menuitem_ec.value < 0x05)
 		*item->parm.menuitem_ec.value = item->parm.menuitem_ec.can_do_zero ? 0x00 : (DPData.cf_explevel_inc_third ? 0x04 : 0x03);
 	else
-		*item->parm.menuitem_ec.value = ec_dec(*item->parm.menuitem_ec.value);
+		*item->parm.menuitem_ec.value = ec_dec(*item->parm.menuitem_ec.value, item->parm.menuitem_ec.extended);
 }
 
 void menuitem_dec_av(const menuitem_t *item, const int repeating) {

--- a/menuitem.c
+++ b/menuitem.c
@@ -185,7 +185,7 @@ void menuitem_inc_sub(const menuitem_t *item, const int repeating) {
 
 void menuitem_dec_ec(const menuitem_t *item, const int repeating) {
 	if (item->parm.menuitem_ec.zero_means_off && *item->parm.menuitem_ec.value < 0x05)
-		*item->parm.menuitem_ec.value = item->parm.menuitem_ec.can_do_zero ? 0x00 : (DPData.cf_explevel_inc_third ? 0x04 : 0x03);
+		*item->parm.menuitem_ec.value = item->parm.menuitem_ec.can_do_zero ? 0x00 : EV_STEP;
 	else
 		*item->parm.menuitem_ec.value = ec_dec(*item->parm.menuitem_ec.value, item->parm.menuitem_ec.extended);
 }

--- a/menuitem.h
+++ b/menuitem.h
@@ -6,6 +6,7 @@
 
 typedef struct {
 	int  *value;
+	int   extended;
 	int   can_do_zero;
 	int   zero_means_off;
 } menuitem_ec_t;
@@ -74,12 +75,13 @@ struct menuitem_t {
 	itemaction_t   change;
 };
 
-#define MENUITEM_EC(_ID_, _NAME_, _VALUE_, _RO_, _CDZ_, _ZMO_, _CHANGE_) { \
+#define MENUITEM_EC(_ID_, _NAME_, _VALUE_, _RO_, _EXT_, _CDZ_, _ZMO_, _CHANGE_) { \
 	id       : _ID_, \
 	name     : _NAME_, \
 	readonly : _RO_, \
 	parm     : { menuitem_ec : { \
 		value          : _VALUE_, \
+		extended       : _EXT_, \
 		can_do_zero    : _CDZ_, \
 		zero_means_off : _ZMO_, \
 	}}, \
@@ -237,10 +239,10 @@ struct menuitem_t {
 	display : menuitem_display_info, \
 }
 
-#define MENUITEM_EVCOMP(_ID_, _NAME_, _VALUE_, _ON_CHANGE_) MENUITEM_EC(_ID_, _NAME_, _VALUE_, FALSE, TRUE,  FALSE, _ON_CHANGE_)
-#define MENUITEM_EVSEP( _ID_, _NAME_, _VALUE_, _ON_CHANGE_) MENUITEM_EC(_ID_, _NAME_, _VALUE_, FALSE, TRUE,  TRUE,  _ON_CHANGE_)
-#define MENUITEM_EVEAEB(_ID_, _NAME_, _VALUE_, _ON_CHANGE_) MENUITEM_EC(_ID_, _NAME_, _VALUE_, FALSE, FALSE, TRUE,  _ON_CHANGE_)
-#define MENUITEM_EVINFO(_ID_, _NAME_, _VALUE_, _ON_CHANGE_) MENUITEM_EC(_ID_, _NAME_, _VALUE_, TRUE,  TRUE,  FALSE, _ON_CHANGE_)
+#define MENUITEM_EVCOMP(_ID_, _NAME_, _VALUE_, _ON_CHANGE_) MENUITEM_EC(_ID_, _NAME_, _VALUE_, FALSE, FALSE, TRUE,  FALSE, _ON_CHANGE_)
+#define MENUITEM_EVSEP( _ID_, _NAME_, _VALUE_, _ON_CHANGE_) MENUITEM_EC(_ID_, _NAME_, _VALUE_, FALSE, FALSE, TRUE,  TRUE,  _ON_CHANGE_)
+#define MENUITEM_EVEAEB(_ID_, _NAME_, _VALUE_, _ON_CHANGE_) MENUITEM_EC(_ID_, _NAME_, _VALUE_, FALSE, FALSE, FALSE, TRUE,  _ON_CHANGE_)
+#define MENUITEM_EVINFO(_ID_, _NAME_, _VALUE_, _ON_CHANGE_) MENUITEM_EC(_ID_, _NAME_, _VALUE_, FALSE, TRUE,  TRUE,  FALSE, _ON_CHANGE_)
 
 #define MENUITEM_BASEISO(_ID_, _NAME_, _VALUE_, _ON_CHANGE_) MENUITEM_ISO(_ID_, _NAME_, _VALUE_, TRUE,  _ON_CHANGE_)
 #define MENUITEM_FULLISO(_ID_, _NAME_, _VALUE_, _ON_CHANGE_) MENUITEM_ISO(_ID_, _NAME_, _VALUE_, FALSE, _ON_CHANGE_)

--- a/shortcuts.c
+++ b/shortcuts.c
@@ -195,7 +195,7 @@ void shortcut_event_right(void) {
 		shortcut_iso_set(iso_inc(DPData.iso));
 		break;
 	case SHORTCUT_AEB:
-		shortcut_aeb_set(MIN(ec_inc(DPData.ae_bkt), EC_MAX));
+		shortcut_aeb_set(MIN(ec_inc(DPData.ae_bkt, FALSE), EC_MAX));
 		break;
 	case SHORTCUT_TOGGLE_FLASH:
 		shortcut_f2c_set(TRUE);
@@ -214,7 +214,7 @@ void shortcut_event_left(void) {
 		shortcut_iso_set(iso_dec(DPData.iso));
 		break;
 	case SHORTCUT_AEB:
-		shortcut_aeb_set(MAX(ec_dec(DPData.ae_bkt), EV_ZERO));
+		shortcut_aeb_set(MAX(ec_dec(DPData.ae_bkt, FALSE), EV_ZERO));
 		break;
 	case SHORTCUT_TOGGLE_FLASH:
 		shortcut_f2c_set(FALSE);

--- a/viewfinder.c
+++ b/viewfinder.c
@@ -28,7 +28,7 @@ void viewfinder_right() {
 	if (settings.autoiso_enable) {
 		// AutoISO + M => change exposure compensation
 		if (DPData.ae == AE_MODE_M)
-			viewfinder_change_evc(ec_inc(persist.ev_comp));
+			viewfinder_change_evc(ec_inc(persist.ev_comp, FALSE));
 	} else {
 		// Only for creative modes
 		if (AE_IS_CREATIVE(DPData.ae))
@@ -40,7 +40,7 @@ void viewfinder_left() {
 	if (settings.autoiso_enable) {
 		// AutoISO + M => change exposure compensation
 		if (DPData.ae == AE_MODE_M)
-			viewfinder_change_evc(ec_dec(persist.ev_comp));
+			viewfinder_change_evc(ec_dec(persist.ev_comp, FALSE));
 	} else {
 		// Only for creative modes
 		if (AE_IS_CREATIVE(DPData.ae))


### PR DESCRIPTION
Hold SET down, while looking through the viewfinder, to enable "fixed exposure; release SET to disable.

Hold DOWN down, while looking through the viewfinder, to enable "quick exposure; release DOWN to disable.

Fixes #394 