### PR TITLE
Fix "fixed exposure" feature

### DIFF
--- a/fexp.c
+++ b/fexp.c
@@ -11,6 +11,13 @@
 
 #include "fexp.h"
 
+void fexp_toggle(void) {
+	if (status.vf_status == VF_STATUS_FEXP)
+		fexp_disable();
+	else
+		fexp_enable();
+}
+
 void fexp_enable(void) {
 	status.vf_status = VF_STATUS_FEXP;
 	status.fexp_ev   = (int)DPData.av_val + (int)DPData.tv_val;

--- a/fexp.h
+++ b/fexp.h
@@ -1,6 +1,8 @@
 #ifndef FEXP_H_
 #define FEXP_H_
 
+extern void fexp_toggle   (void);
+
 extern void fexp_enable   (void);
 extern void fexp_disable  (void);
 

--- a/intercom.c
+++ b/intercom.c
@@ -215,6 +215,9 @@ int proxy_dialog_afoff(char *message) {
 int proxy_measuring(char *message) {
 	status.measuring = message[2];
 
+	if (status.vf_status == VF_STATUS_FEXP && ! status.measuring)
+		fexp_disable();
+
 	return FALSE;
 }
 

--- a/viewfinder.c
+++ b/viewfinder.c
@@ -78,7 +78,7 @@ void viewfinder_down() {
 void viewfinder_set() {
 	switch (DPData.ae) {
 	case AE_MODE_M:
-		fexp_enable();
+		fexp_toggle();
 		break;
 	case AE_MODE_P:
 	case AE_MODE_TV:
@@ -111,9 +111,6 @@ void viewfinder_end() {
 		break;
 	case(VF_STATUS_MSM):
 		msm_release();
-		break;
-	case(VF_STATUS_FEXP):
-		fexp_disable();
 		break;
 	case(VF_STATUS_QEXP):
 		qexp_disable();


### PR DESCRIPTION
The SET button does not have the HOLD property, so we cannot detect when
is released, and thus the fixed exposure feature got stuck. Now, it can
be pressed once to enable the feature, and once again to disable it;
also, when the camera stops metering, the feature is disabled.

Fixes issue #424.